### PR TITLE
ci: use GitHub-hosted runners (drop inherited Blacksmith config)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,13 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout code
@@ -32,7 +36,7 @@ jobs:
           TURBO_TEAM: team_fluxer
 
   test:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout code
@@ -59,7 +63,7 @@ jobs:
           TURBO_TEAM: team_fluxer
 
   gateway:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout code
@@ -93,7 +97,7 @@ jobs:
           FLUXER_CONFIG: ../config/config.test.json
 
   knip:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout code
@@ -119,7 +123,7 @@ jobs:
           TURBO_TEAM: team_fluxer
 
   ci-scripts:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem
The `CI` workflow (`ci.yaml`) pins all 5 jobs to `runs-on: blacksmith-8vcpu-ubuntu-2404`. Those Blacksmith runner labels were inherited from upstream CI infra and were never connected to this fork (no Blacksmith app/account). With no runner to claim them, every job sat queued for GitHub's 24h maximum then auto-cancelled — so CI has **never actually run** on a PR (3/3 runs cancelled, 0 steps executed).

## Fix
- Point all 5 jobs (`typecheck`, `test`, `gateway`, `knip`, `ci-scripts`) at `ubuntu-24.04` — free GitHub-hosted runners on public repos, matching the Ubuntu 24.04 the Blacksmith label used.
- Add a `cancel-in-progress` concurrency group so superseded pushes cancel cleanly instead of lingering for 24h.

## Notes
- First real CI run may surface pre-existing issues (nothing has ever been checked) — expected, triage separately.
- `TURBO_TOKEN`/`TURBO_API` left as-is; Turbo falls back to no remote cache if the secret is unset.