### PR TITLE
ci: skip wasm-pack postinstall so pnpm install succeeds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ allowBuilds:
   ssh2: true
   sqlite3: true
   uiohook-napi: true
-  wasm-pack: true
+  wasm-pack: false
 blockExoticSubdeps: true
 minimumReleaseAge: 1440
 strictDepBuilds: true


### PR DESCRIPTION
## Problem
`pnpm install --frozen-lockfile` aborts because `wasm-pack@0.14.0`'s postinstall 404s downloading its prebuilt binary — the `drager/wasm-pack` **v0.14.0 GitHub release genuinely does not exist** upstream (npm has the package, GitHub releases don't). With `strictDepBuilds: true`, that failed allowed-build is fatal, so the `typecheck`, `test`, and `knip` jobs die at the shared install step **before their actual check runs** (3 of the 5 red jobs, one cause).

## Fix
Set `wasm-pack: false` in `allowBuilds` (explicit deny, required by `strictDepBuilds`) so pnpm installs the package but **skips its broken postinstall**. The wasm-pack binary is only used by the manual `wasm:codegen` script — no CI check depends on it.

## Notes
- One line, no lockfile change (lockfile `settings:` doesn't record build policy).
- This unblocks measurement: it's the only way this CI run can finally exercise typecheck/test/knip, including the e2ee group-session server types.
- Gateway (2 real Erlang bugs) and ci-scripts (empty pytest) are separate, tracked, not addressed here.