### PR TITLE
fix(api): channel + e2ee message typecheck gaps

### DIFF
--- a/packages/api/src/database/types/MessageTypes.tsx
+++ b/packages/api/src/database/types/MessageTypes.tsx
@@ -167,12 +167,22 @@ export interface MessageRow {
 
 // Stored verbatim — the server never reads inside this. The shape is
 // agreed on between sender and recipient clients via the wire schema.
-export interface MessageEncryptedPayload {
-	v: number;
-	sender_device_id: string;
-	sender_identity_key: string;
-	ciphertexts: Record<string, {type: number; body: string}>;
-}
+export type MessageEncryptedPayload =
+	| {
+			v: number;
+			kind?: 'olm';
+			sender_device_id: string;
+			sender_identity_key: string;
+			ciphertexts: Record<string, {type: number; body: string}>;
+	  }
+	| {
+			v: number;
+			kind: 'megolm';
+			sender_device_id: string;
+			sender_identity_key: string;
+			session_id: string;
+			ciphertext: string;
+	  };
 
 export const MESSAGE_COLUMNS = [
 	'channel_id',

--- a/packages/api/src/guild/services/channel/ChannelOperationsService.tsx
+++ b/packages/api/src/guild/services/channel/ChannelOperationsService.tsx
@@ -165,6 +165,7 @@ export class ChannelOperationsService {
 			nicks: null,
 			soft_deleted: false,
 			indexed_at: null,
+			e2ee_enabled: false,
 			version: 1,
 		});
 

--- a/packages/api/src/rpc/RpcService.tsx
+++ b/packages/api/src/rpc/RpcService.tsx
@@ -330,6 +330,7 @@ export class RpcService {
 			nicks: null,
 			soft_deleted: false,
 			indexed_at: null,
+			e2ee_enabled: false,
 			version: 1,
 		});
 	}

--- a/packages/api/src/test/TestHarnessController.tsx
+++ b/packages/api/src/test/TestHarnessController.tsx
@@ -996,6 +996,7 @@ export function TestHarnessController(app: HonoApp) {
 				nicks: null,
 				soft_deleted: false,
 				indexed_at: null,
+				e2ee_enabled: true,
 				version: 1,
 			};
 
@@ -1037,6 +1038,7 @@ export function TestHarnessController(app: HonoApp) {
 					nicks: null,
 					soft_deleted: false,
 					indexed_at: null,
+					e2ee_enabled: true,
 					version: 1,
 				};
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ allowBuilds:
   ssh2: true
   sqlite3: true
   uiohook-napi: true
-  wasm-pack: true
+  wasm-pack: false
 blockExoticSubdeps: true
 minimumReleaseAge: 1440
 strictDepBuilds: true


### PR DESCRIPTION
Stacked on #12 (base = `ci/skip-wasm-pack-build`) so CI can actually run — without the wasm-pack fix the install step 404s and typecheck never executes. **Auto-retargets to `refactor` when #12 merges.**

Fixes 5 of the ~18 API type errors the first real CI run surfaced. Two separate commits:

**1. `ChannelRow.e2ee_enabled` fills (4 sites)** — the always-on migration made the column required (full-row-insert), but four builders omitted it (TS2741). Guild + personal-notes → `false`; test-harness DM/GROUP_DM → `true` (matches `ChannelMappers`/`UserChannel*`).

**2. `MessageEncryptedPayload` → Olm|Megolm union** — the DB type was Olm-only while the wire schema already had the union; assigning a megolm (group-DM) payload failed (TS2322). Mirrors the wire schema. Server stores verbatim / never reads inside, so no narrowing needed (verified).

⚠️ **Does not fully green the `test` job** — the remaining API errors (`grantUserPremium`, `User.avatar`, `Klipy.locale`, etc.) are separate decisions, not in scope here. **Do not merge** — opened to review the CI delta.