### PR TITLE
ci: validate green state (do not merge)

### DIFF
--- a/ci-validation.md
+++ b/ci-validation.md
@@ -1,0 +1,3 @@
+# CI validation (re-run)
+
+Full-suite re-run after the EndpointDerivation + all 2026-06-09 fixes. Not for merge.


### PR DESCRIPTION
Throwaway PR to run the full CI suite over the 2026-06-09 fixes. Confirms which jobs go green; close after.