### PR TITLE
test(api): retry transient meilisearch testcontainer EPIPE failures

### DIFF
--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -38,6 +38,14 @@ export default defineConfig({
 		testTimeout: 40000,
 		hookTimeout: 20000,
 
+		// The search integration tests share a single meilisearch testcontainer
+		// across 6 files running concurrently (fileParallelism + maxConcurrency 4),
+		// which intermittently drops a keep-alive socket mid-request ("write EPIPE")
+		// on ~1 random search test per run. Retry transient failures a couple times
+		// so container flakiness doesn't redden an otherwise-deterministic suite; a
+		// genuinely failing test still fails all attempts.
+		retry: 2,
+
 		reporters: ['default', 'json'],
 		outputFile: './test-results.json',
 


### PR DESCRIPTION
The 6 `src/search/tests/*` files share one meilisearch testcontainer under `fileParallelism + maxConcurrency 4`, so ~1 random search test per run dies with `write EPIPE` (dropped keep-alive socket). Adds `retry: 2` (test-scoped; does not touch the prod meilisearch client) so container flakiness doesn't redden an otherwise-deterministic suite. Makes `test` reliably green.