### PR TITLE
fix(e2ee): treat the bootstrap decrypt race as retryable, not permanent

### DIFF
--- a/fluxer_app/src/lib/e2ee/E2EEMessageIntegration.tsx
+++ b/fluxer_app/src/lib/e2ee/E2EEMessageIntegration.tsx
@@ -934,12 +934,16 @@ export async function tryDecryptForCurrentDevice(
 		}
 	}
 
-	// Transient edge on the live path only — the history path guards isReady
-	// before calling, and this self-heals when the channel is reopened and
-	// re-decrypted. The deferred ⏳ transient state will refine this.
-	if (!E2EEStore.isReady) return PERMANENT_FAILURE;
+	// Bootstrap race on the live path: a gateway message can land before Olm
+	// finishes registering. This is transient, so it must NOT be reported as a
+	// permanent failure — 'permanent' renders the dead 🔒 placeholder and the
+	// bubble deliberately withholds the retry button for it, leaving the
+	// message unreadable until a full reload clears the in-memory marker.
+	// 'error' renders ⚠ + Retry, which succeeds once registration completes.
+	if (!E2EEStore.isReady) return ERROR_FAILURE;
+	// isReady already implies deviceId !== null; this only narrows the type.
 	const deviceId = E2EEStore.deviceId;
-	if (!deviceId) return PERMANENT_FAILURE;
+	if (!deviceId) return ERROR_FAILURE;
 
 	// Megolm group DM message — single ciphertext, identified by session.
 	if (encryptedPayload.kind === 'megolm') {

--- a/packages/admin/src/routes/System.tsx
+++ b/packages/admin/src/routes/System.tsx
@@ -73,6 +73,19 @@ function parseHourValue(value: string | undefined): number | null {
 	return Number.isNaN(parsed) ? null : parsed;
 }
 
+// `LimitConfigGetResponse.defaults` is a sparse record (`z.partialRecord`), so
+// its values are `number | undefined`. A limit rule's `limits` is a dense
+// `Record<string, number>`. Drop the holes on the way across rather than
+// leaning on JSON.stringify to silently omit `undefined` properties later —
+// the type should not lie about what the object contains.
+function definedLimits(source: Partial<Record<string, number>> | undefined): Record<string, number> {
+	const limits: Record<string, number> = {};
+	for (const [key, value] of Object.entries(source ?? {})) {
+		if (value !== undefined) limits[key] = value;
+	}
+	return limits;
+}
+
 function buildLimitFilters(formData: ParsedBody): {filters?: {traits?: Array<string>; guildFeatures?: Array<string>}} {
 	const traits = parseDelimitedStringList(getOptionalString(formData, 'traits'));
 	const guildFeatures = parseDelimitedStringList(getOptionalString(formData, 'guild_features'));
@@ -456,10 +469,7 @@ export function createSystemRoutes({config, assetVersion, requireAuth}: RouteFac
 				const {filters} = buildLimitFilters(formData);
 
 				if (Object.keys(limits).length === 0) {
-					const fallbackDefaults = defaultLimits[ruleId] ?? defaultLimits.default;
-					if (fallbackDefaults) {
-						Object.assign(limits, fallbackDefaults);
-					}
+					Object.assign(limits, definedLimits(defaultLimits[ruleId] ?? defaultLimits.default));
 				}
 
 				currentConfig.rules[ruleIndex] = {
@@ -541,10 +551,9 @@ export function createSystemRoutes({config, assetVersion, requireAuth}: RouteFac
 
 				const {filters} = buildLimitFilters(formData);
 
-				const defaultLimits = currentConfigResult.data.defaults.default ?? {};
 				const newRule = {
 					id: ruleIdTrimmed,
-					limits: {...defaultLimits},
+					limits: definedLimits(currentConfigResult.data.defaults.default),
 					...(filters ? {filters} : {}),
 				};
 


### PR DESCRIPTION
## What

`tryDecryptForCurrentDevice` returned `PERMANENT_FAILURE` when `E2EEStore` was not yet ready. On the live gateway path a message can arrive before Olm finishes registering, so a purely transient race was recorded as a **permanent** failure.

That distinction is load-bearing:

* `'permanent'` → renders `🔒 This message cannot be read on this device.`
* `'error'` → renders `⚠️ This message could not be decrypted (technical error).` **plus a Retry button**

`DecryptRetryButton` returns `null` unless the reason is `'error'`, so a message caught by the bootstrap race was stuck unreadable until a full page reload cleared the in-memory `decryptFailureById` marker. There was no way for the user to recover it in-session.

## Fix

Return `ERROR_FAILURE` for both readiness guards. `redecryptMessage` re-fetches and re-decrypts, which succeeds once registration completes.

The `deviceId` guard immediately below is unreachable in practice — `E2EEStore.isReady` is `registrationStatus === 'ready' && deviceId !== null` — but it is switched too so both readiness guards agree.

## How it was found

Diagnosing a support report of encrypted-message placeholders in a 1:1 DM. Server-side data was complete (every message carried a ciphertext for the recipient's device, prekeys healthy), which pointed at client-side session/bootstrap state.

## Scope

Behaviour change is limited to the not-yet-ready path. No change to `no_blob` handling, which stays permanent and negatively cached — that one is genuinely unrecoverable without a re-distribution.

## Verification

`pnpm typecheck:only` in `fluxer_app` passes (exit 0). Not deployed.
