### PR TITLE
fix(e2ee): stop the key store from being wiped or evicted

### DIFF
--- a/fluxer_app/src/lib/e2ee/E2EEKeyStore.tsx
+++ b/fluxer_app/src/lib/e2ee/E2EEKeyStore.tsx
@@ -250,6 +250,26 @@ async function openDB(): Promise<IDBDatabase> {
 	}
 }
 
+// The Olm identity, every session, and the decrypted-message cache all live in
+// this IndexedDB. Without an explicit grant the origin is "best-effort" storage
+// that the browser may evict under disk pressure — and an evicted store reads
+// to doBootstrap() as "no account", costing the user a brand-new identity, all
+// of their decryptable history, and a permanent slot in every peer's encrypt
+// fan-out. The grant is sticky, so asking once is enough.
+//
+// Best-effort by contract: never throws, never blocks bootstrap. Note that
+// Firefox surfaces a permission prompt here; Chromium auto-grants for
+// installed apps and decides heuristically otherwise.
+export async function requestPersistentStorage(): Promise<boolean> {
+	try {
+		if (typeof navigator === 'undefined' || !navigator.storage?.persist) return false;
+		if (await navigator.storage.persisted()) return true;
+		return await navigator.storage.persist();
+	} catch {
+		return false;
+	}
+}
+
 function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
 	return new Promise((resolve, reject) => {
 		req.onsuccess = () => resolve(req.result);

--- a/fluxer_app/src/lib/e2ee/E2EEKeyStore.tsx
+++ b/fluxer_app/src/lib/e2ee/E2EEKeyStore.tsx
@@ -217,18 +217,33 @@ function deleteDB(): Promise<void> {
 	});
 }
 
+// A stored database at a HIGHER version than this build expects is the one
+// failure IndexedDB genuinely cannot recover from — it refuses to downgrade.
+// Everything else (a second tab holding the connection, a quota trip, a
+// transient backing-store error) is recoverable and must never cost the user
+// their identity.
+function isVersionError(err: unknown): boolean {
+	return err instanceof DOMException && err.name === 'VersionError';
+}
+
 async function openDB(): Promise<IDBDatabase> {
 	if (dbInstance) return dbInstance;
 	try {
 		dbInstance = await attemptOpen();
 		return dbInstance;
-	} catch {
-		// Most likely cause: an older build left the DB at a higher
-		// version than the current code expects (e.g., the rolled-back v3
-		// `message_plaintexts` ship). The DB can't be downgraded, so wipe
-		// it and rebuild fresh. Olm sessions are lost, but bootstrap will
-		// auto-re-register a new device on the next tick — better than
-		// leaving the user permanently unable to set up E2EE.
+	} catch (err) {
+		// Deleting this database destroys the Olm identity, every Olm and
+		// Megolm session, and the whole decrypted-message cache — and
+		// doBootstrap reads the resulting empty store as "first run" and
+		// silently mints a NEW device. So only wipe for the one error that
+		// leaves no alternative: a stored version newer than this build.
+		//
+		// Anything else is rethrown, which puts E2EEStore into
+		// registrationStatus='error' and retries on the next gateway READY.
+		// Previously this catch was unqualified, so an `onblocked` reject
+		// from merely opening a second tab silently destroyed the user's
+		// history and identity.
+		if (!isVersionError(err)) throw err;
 		await deleteDB();
 		dbInstance = await attemptOpen();
 		return dbInstance;

--- a/fluxer_app/src/stores/E2EEStore.tsx
+++ b/fluxer_app/src/stores/E2EEStore.tsx
@@ -28,6 +28,7 @@ import {
 	getVerification,
 	getVerificationsForUser,
 	putVerification,
+	requestPersistentStorage,
 	setPeerIdentityKey,
 	type VerificationEntry,
 } from '@app/lib/e2ee/E2EEKeyStore';
@@ -379,6 +380,14 @@ class E2EEStore {
 			this.registrationStatus = 'initialising';
 			this.lastError = null;
 			this.pendingBackup = null;
+		});
+
+		// Ask the browser to stop evicting our IndexedDB. Fire-and-forget: an
+		// evicted store is indistinguishable from a first run (see the gate
+		// below), so this guards the identity — but it must never delay E2EE
+		// setup, and Firefox raises a permission prompt here.
+		void requestPersistentStorage().then((persisted) => {
+			logger.debug('E2EE storage persistence', {persisted});
 		});
 
 		await e2eeManager.initForUser(userId);


### PR DESCRIPTION
> **Stacked on #21.** Based on `fix/e2ee-bootstrap-decrypt-retryable` because `refactor` does not currently typecheck (`@fluxer/admin`, broken by `cf99eadc` — fixed in #21). GitHub will retarget this to `refactor` when #21 merges. Review only the two commits below.

Two independent fixes to how the E2EE key store survives, found while root-causing a user who has accumulated **31 Olm identities**, one per app launch.

---

## 1. `fix(e2ee): only wipe the key store on a genuine VersionError`

`openDB()` caught **every** failure from `indexedDB.open()` and responded by deleting the database:

```js
try   { dbInstance = await attemptOpen(); return dbInstance; }
catch { await deleteDB(); dbInstance = await attemptOpen(); return dbInstance; }
```

`FluxerE2EE` holds the Olm identity, every Olm and Megolm session, and the decrypted-message cache. And `doBootstrap`'s only gate is:

```js
if (e2eeManager.hasAccount() && e2eeManager.currentDeviceId) { …return; }
await this.registerFreshDevice(userId);
```

So the resulting empty store reads as *first run* and silently mints a new device. The old comment said as much: *"Olm sessions are lost, but bootstrap will auto-re-register a new device on the next tick."*

**`attemptOpen()` rejects on `onblocked` as well as `onerror`** — so opening the app in a second tab could destroy a user's identity and their entire readable history. `QuotaExceededError`, `AbortError` and transient backing-store errors did the same.

Only a `VersionError` (stored DB newer than this build; IndexedDB refuses to downgrade) leaves no alternative to a wipe. Narrowed the catch to that case; everything else rethrows into E2EEStore's existing bootstrap catch, which sets `registrationStatus='error'` and retries on the next gateway READY.

`openDB()` could already reject before this change — the second `attemptOpen()` sits outside the `try` — so callers already tolerate it.

## 2. `fix(e2ee): request persistent storage for the key store`

`navigator.storage.persist()` was never called anywhere, so the identity lived in **best-effort, evictable storage**. An evicted store is indistinguishable from a first run, so eviction costs the user their history and gives them a permanent slot in every peer's encrypt fan-out — the server never prunes device registrations.

Requested once at bootstrap: sticky, best-effort by contract (never throws), and **fire-and-forget** so it cannot delay E2EE setup.

⚠️ **Firefox raises a permission prompt** for `persist()`. Chromium auto-grants for installed apps and decides heuristically otherwise. That's the one user-visible change here.

---

## What this does and does not fix

Stops eviction, and stops a second tab from nuking a user's identity. It does **not** fix a clear-on-close browser setting, and it does **not** fix the underlying defect: `doBootstrap` still cannot tell *"no account"* from *"account was wiped"*. That needs a durable breadcrumb outside IndexedDB plus a **non-blocking** recovery state — non-blocking because a hard error would reintroduce the stuck-user regression that `E2EEStore.tsx:396-404` was written to avoid.

## Verification

`pnpm typecheck:only` in `fluxer_app` passes. Not deployed.

## Context

One user: 31 devices, 31 distinct identity keys, all `device_name="Windows"`, registered 12–31 seconds before each first message. Their peer's per-message fan-out grew 20 → 32 ciphertexts. Device counts across 190 users are `{1:132, 2:37, 3:10, 4:4, 5:2, 6:1, 8:2, 11:1, 31:1}` — an outlier, not a build-wide regression.

Note for whoever picks up server-side GC: `last_seen_at` is a dead field (324/326 rows have it equal to `created_at`). A 30-day reaper would delete the sole device of **65 of the 132 single-device users** while pruning only 14 of the 31. Fix the write path first.
